### PR TITLE
Replace deprecated bs4Box with bs4Dash box

### DIFF
--- a/R/mod_admin_users.R
+++ b/R/mod_admin_users.R
@@ -1,10 +1,10 @@
-# R/mod_admin_users.R — správa uživatelů (bs4Box + shiny::modalDialog modály)
+# R/mod_admin_users.R — správa uživatelů (box + shiny::modalDialog modály)
 
 mod_admin_users_ui <- function(id){
   ns <- NS(id)
   tagList(
     fluidRow(
-      bs4Box(
+      box(
         title = tagList(icon("users-cog"), span(" Uživatelé")),
         status = "primary", solidHeader = TRUE, width = 12, closable = FALSE,
         DT::DTOutput(ns("tbl")),

--- a/R/mod_auth.R
+++ b/R/mod_auth.R
@@ -8,7 +8,7 @@ mod_auth_ui <- function(id){
   fluidRow(
     column(
       width = 6, offset = 3,
-      bs4Box(
+      box(
         title = tagList(icon("sign-in-alt"), span(" Přihlášení")),
         status = "primary", solidHeader = TRUE, width = 12, closable = FALSE,
         textInput(ns("email"), "E-mail"),

--- a/R/mod_setup.R
+++ b/R/mod_setup.R
@@ -38,7 +38,7 @@ mod_setup_ui <- function(id){
     fluidRow(
       column(
         width = 6,
-        bs4Box(
+        box(
           title = tagList(icon("database"), span(" Krok 1 – Připojení k databázi")),
           status = "info", solidHeader = TRUE, width = 12, closable = FALSE,
           textInput(ns("host"),   "Host",   value = "127.0.0.1"),
@@ -54,7 +54,7 @@ mod_setup_ui <- function(id){
       ),
       column(
         width = 6,
-        bs4Box(
+        box(
           title = tagList(icon("cogs"), span(" Krok 2 – Inicializace a admin")),
           status = "warning", solidHeader = TRUE, width = 12, closable = FALSE,
           uiOutput(ns("meta_status")),

--- a/app.R
+++ b/app.R
@@ -158,7 +158,7 @@ server <- function(input, output, session){
   output$content_panel <- renderUI({
     req(app_ready(), current_user())
     u <- current_user()
-    bs4Box(
+    box(
       title = tagList(icon("table"), span(" Obsah")),
       status = "primary", width = 12, solidHeader = TRUE, closable = FALSE, maximizable = FALSE,
       HTML(sprintf("<p><b>Přihlášený uživatel:</b> %s &lt;%s&gt;</p>", u$display_name, u$email)),


### PR DESCRIPTION
## Summary
- Replace deprecated `bs4Box` calls with `box` to support bs4Dash 2.3.5
- Update admin user module comment to reflect `box` usage

## Testing
- ⚠️ `R -q -e "devtools::test()"` *(R not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdac621408320879221aca288c61a