### PR TITLE
Organize menu into planning and settings groups

### DIFF
--- a/app.R
+++ b/app.R
@@ -41,10 +41,19 @@ ui <- bs4DashPage(
     title = "Menu",
     bs4SidebarMenu(
       id = "sidebar_tabs",
-      bs4SidebarMenuItem("Instalace systému", tabName = "setup",   icon = icon("wrench")),
-      bs4SidebarMenuItem("Přihlášení",        tabName = "login",   icon = icon("sign-in-alt")),
-      bs4SidebarMenuItem("Obsah",             tabName = "content", icon = icon("table")),
-      bs4SidebarMenuItem("Správa uživatelů",  tabName = "admin",   icon = icon("users-cog"))
+      bs4SidebarMenuItem(
+        "Plánování",
+        icon = icon("calendar"),
+        startExpanded = TRUE,
+        bs4SidebarMenuSubItem("Obsah", tabName = "content", icon = icon("table"))
+      ),
+      bs4SidebarMenuItem(
+        "Nastavení",
+        icon = icon("cogs"),
+        bs4SidebarMenuSubItem("Instalace systému", tabName = "setup", icon = icon("wrench")),
+        bs4SidebarMenuSubItem("Přihlášení",        tabName = "login",  icon = icon("sign-in-alt")),
+        bs4SidebarMenuSubItem("Správa uživatelů",  tabName = "admin",  icon = icon("users-cog"))
+      )
     )
   ),
   


### PR DESCRIPTION
## Summary
- Split sidebar into two levels: "Plánování" with "Obsah" and "Nastavení" for system setup, login, and user management

## Testing
- `R -q -e "lintr::lint('app.R')"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c00bdefbe08320b4adf8e564c3f6ad