### PR TITLE
Fix dark background in user grid

### DIFF
--- a/R/mod_admin_users.R
+++ b/R/mod_admin_users.R
@@ -32,8 +32,13 @@ mod_admin_users_server <- function(id, pool, on_roles_changed = NULL){
     users  <- reactive({ reload(); sql_list_users(pool) })
     
     output$tbl <- DT::renderDT({
-      DT::datatable(users(), selection = "single", rownames = FALSE,
-                    options = list(pageLength = 10, order = list(list(0, "asc"))))
+      DT::datatable(
+        users(),
+        selection = "single",
+        rownames = FALSE,
+        options = list(pageLength = 10, order = list(list(0, "asc"))),
+        style = "bootstrap4"
+      )
     }, server = TRUE)
     
     selected_user_id <- reactive({


### PR DESCRIPTION
## Summary
- Use Bootstrap 4 styling for the user admin DataTable to avoid dark background

## Testing
- `R -q -e 'sessionInfo()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0118ffa8c8320b525a096bd068838