### PR TITLE
Sync help panel with dark mode

### DIFF
--- a/app.R
+++ b/app.R
@@ -82,6 +82,11 @@ ui <- bs4DashPage(
             $sidebar.removeClass('sidebar-dark-primary sidebar-light-primary')
                     .addClass(dark ? 'sidebar-dark-primary' : 'sidebar-light-primary');
           }
+          var $cbar = $('aside.control-sidebar');
+          if ($cbar.length){
+            $cbar.removeClass('control-sidebar-dark control-sidebar-light')
+                 .addClass(dark ? 'control-sidebar-dark' : 'control-sidebar-light');
+          }
         }
         // Apply at start
         $(applyState);


### PR DESCRIPTION
## Summary
- Keep help controlbar skin in sync with dark/light theme.

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c013372f88832093fbe57e833d75a8