### PR TITLE
Split setup wizard into three steps and restrict admin creation

### DIFF
--- a/help/setup.md
+++ b/help/setup.md
@@ -1,5 +1,4 @@
 # Instalace systému
-1. Vyplňte parametry připojení k PostgreSQL.
-2. Otestujte připojení.
-3. Inicializujte metadata.
-4. Vytvořte admin účet.
+1. Vyplňte parametry připojení k PostgreSQL a otestujte připojení.
+2. Inicializujte metadata.
+3. Vytvořte admin účet (pouze pokud ještě neexistuje).


### PR DESCRIPTION
## Summary
- Split installation wizard into three steps, moving admin creation to the third step.
- Restrict admin creation to only when no existing administrator is present.
- Update setup documentation to describe the three-step process.

## Testing
- `R -q -e 'lintr::lint("R/mod_setup.R")'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c014e6cdf4832080fd0d38099fa205