### PR TITLE
Add notification subsystem with user menu integration

### DIFF
--- a/sql/init_auth.sql
+++ b/sql/init_auth.sql
@@ -37,6 +37,14 @@ create table if not exists app_meta.session_log(
   user_agent  text
 );
 
+create table if not exists app_meta.notification(
+  notification_id bigserial primary key,
+  user_id         bigint references app_meta.user_account(user_id) on delete cascade,
+  message         text not null,
+  is_read         boolean not null default false,
+  created_at      timestamptz not null default now()
+);
+
 create or replace function app_meta.tg_updated_at() returns trigger
 language plpgsql as $$
 begin


### PR DESCRIPTION
## Summary
- add `app_meta.notification` table for user notifications
- provide SQL helpers to create and fetch notifications for specific users or all
- integrate notifications menu and panel in Shiny UI
- allow metadata initialization script to run repeatedly for updates

## Testing
- `Rscript -e "cat('test')"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c01d447cf08320ab8d92b684cf2839