### PR TITLE
Enable notifications tab via menu link

### DIFF
--- a/app.R
+++ b/app.R
@@ -44,6 +44,11 @@ ui <- bs4DashPage(
         bs4SidebarMenuSubItem("Obsah", tabName = "content", icon = icon("table"))
       ),
       bs4SidebarMenuItem(
+        "Notifikace",
+        tabName = "notifications",
+        icon = icon("bell")
+      ),
+      bs4SidebarMenuItem(
         "Nastavení",
         icon = icon("cogs"),
         bs4SidebarMenuSubItem("Instalace systému", tabName = "setup", icon = icon("wrench")),
@@ -55,11 +60,9 @@ ui <- bs4DashPage(
   
   body = bs4DashBody(
     useShinyjs(),
-    
+
     # Skryj zbylé (nefunkční) theme přepínače
-    tags$head(tags$style(HTML(" 
-      .custom-control.custom-switch { display:none !important; }
-    "))),
+    tags$head(tags$style(HTML("\n      .custom-control.custom-switch { display:none !important; }\n      li.nav-item a[data-value='notifications'] { display:none !important; }\n    "))),
     
     # JS: Dark/Light přepínač s perzistencí + ikona moon/sun
     tags$script(HTML("


### PR DESCRIPTION
## Summary
- add hidden sidebar tab for notifications
- hide notifications link in sidebar with CSS to keep header dropdown navigation

## Testing
- `Rscript -e 'sessionInfo()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c035e0a078832083dea5c07769b4d6