### PR TITLE
Fix notification dropdown count reset when no alerts remain

### DIFF
--- a/app.R
+++ b/app.R
@@ -176,7 +176,7 @@ server <- function(input, output, session){
       type = "notifications", icon = icon("user"),
       .list = items,
       badgeStatus = if (n > 0) "danger" else NULL,
-      show = if (n > 0) n else NULL
+      show = n
     )
   })
 


### PR DESCRIPTION
## Summary
- Ensure notification dropdown counter resets to 0 by always providing `show` value

## Testing
- `apt-get update` *(fails: repository InRelease not signed)*
- `Rscript -e "sessionInfo()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c039372bfc8320bbac40c99d51d6e0