### PR TITLE
Fix notification count for user menu in bs4DropdownMenu

### DIFF
--- a/app.R
+++ b/app.R
@@ -170,13 +170,18 @@ server <- function(input, output, session){
     lbl <- if (is.null(cu)) "Přihlásit se" else "Odhlásit se"
     footer <- tagList(
       if (n > 0) dropdownDivider(),
-      actionLink("open_notifications", "Notifikace", class = "dropdown-item"),
-      actionLink("login_logout", lbl, class = "dropdown-item")
+      div(
+        class = "dropdown-footer",
+        actionLink("open_notifications", "Notifikace", class = "dropdown-item"),
+        actionLink("login_logout", lbl, class = "dropdown-item")
+      )
     )
     bs4DropdownMenu(
       type = "notifications", icon = icon("user"),
+      header = paste(n, "notifications"),
       .list = items,
       badgeStatus = if (n > 0) "danger" else NULL,
+      badgeText = if (n > 0) n else NULL,
       footer = footer
     )
   })


### PR DESCRIPTION
## Summary
- Explicitly set dropdown header and badge text from notification count
- Prevent footer links from being counted in notifications

## Testing
- ❌ `Rscript -e "1+1"` *(command not found: Rscript)*
- ⚠️ `apt-get update` *(403 Forbidden for ubuntu repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68c042adfab4832081a9cf4cd90855e7