### PR TITLE
Remove custom header from notifications dropdown

### DIFF
--- a/app.R
+++ b/app.R
@@ -178,7 +178,6 @@ server <- function(input, output, session){
     )
     bs4DropdownMenu(
       type = "notifications", icon = icon("user"),
-      header = paste(n, "notifications"),
       .list = items,
       badgeStatus = if (n > 0) "danger" else NULL,
       badgeText = if (n > 0) n else NULL,


### PR DESCRIPTION
## Summary
- rely on built-in header for user notifications menu by dropping custom `header` argument

## Testing
- `Rscript -e 'lintr::lint("app.R")'` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c045be3f4883208012b7602abca5de