### PR TITLE
Fix navbar right UI items for bs4Dash

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -34,13 +34,26 @@ app_ui <- function(request) {
       title = shiny::tags$span("RBudgeting"),
       skin = "dark",
       rightUi = shiny::tagList(
-        bs4Dash::dropdownMenuOutput("notifications"),
-        shinyWidgets::materialSwitch(
-          inputId = "theme_toggle",
-          label = "Dark mode",
-          status = "primary"
+        shiny::tags$li(
+          class = "nav-item dropdown",
+          bs4Dash::dropdownMenuOutput("notifications")
         ),
-        shiny::actionButton("logout", label = "Logout", icon = shiny::icon("sign-out-alt"))
+        shiny::tags$li(
+          class = "nav-item",
+          shinyWidgets::materialSwitch(
+            inputId = "theme_toggle",
+            label = "Dark mode",
+            status = "primary"
+          )
+        ),
+        shiny::tags$li(
+          class = "nav-item",
+          shiny::actionButton(
+            "logout",
+            label = "Logout",
+            icon = shiny::icon("sign-out-alt")
+          )
+        )
       ),
       controlbarIcon = shiny::icon("sliders-h")
     ),


### PR DESCRIPTION
## Summary
- wrap navbar right UI elements in `li` tags to satisfy bs4Dash expectations
- ensure dropdown, switch, and logout button render inside navbar without tag assertion errors

## Testing
- attempted `R -q -e "pkgload::load_all(export_all = FALSE)"` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6cccbe58832086d87cc53073788d