### PR TITLE
Fix navbar item classes for bs4Dash compatibility

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -39,7 +39,7 @@ app_ui <- function(request) {
           bs4Dash::dropdownMenuOutput("notifications")
         ),
         shiny::tags$li(
-          class = "nav-item",
+          class = "nav-item dropdown",
           shinyWidgets::materialSwitch(
             inputId = "theme_toggle",
             label = "Dark mode",
@@ -47,7 +47,7 @@ app_ui <- function(request) {
           )
         ),
         shiny::tags$li(
-          class = "nav-item",
+          class = "nav-item dropdown",
           shiny::actionButton(
             "logout",
             label = "Logout",


### PR DESCRIPTION
## Summary
- ensure all navbar right-side list items carry the `dropdown` class so `bs4Dash::bs4DashNavbar` validation passes

## Testing
- not run (R runtime is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ca6d7be1b88320a6b9b304dcb7e0f7