### PR TITLE
Fix golem config lookup

### DIFF
--- a/R/app_config.R
+++ b/R/app_config.R
@@ -4,9 +4,9 @@
 get_golem_config <- function(config = c("default", "production")) {
   config <- match.arg(config)
   config::get(
-    value = config,
-    config = "golem-config.yml",
-    package = "RBudgeting"
+    config = config,
+    file = app_sys("golem-config.yml"),
+    use_parent = FALSE
   )
 }
 


### PR DESCRIPTION
## Summary
- correct the arguments passed to config::get when loading the golem configuration
- ensure the configuration file is resolved via the package helper

## Testing
- not run (R is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ca7236d93c8320a24713ca9145e3ef