### PR TITLE
Remove usage of non-exported shinymanager theme helper

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -114,9 +114,6 @@ app_ui <- function(request) {
       shiny::tags$h2("RBudgeting"),
       shiny::tags$p("Secure authentication provided by shinymanager.")
     ),
-    theme = shinymanager::create_custom_theme(
-      color = "#1f2d3d",
-      hover = "#3c8dbc"
-    )
+    theme = NULL
   )
 }


### PR DESCRIPTION
## Summary
- drop usage of shinymanager::create_custom_theme which is not exported
- fall back to default theme configuration for the secure app wrapper

## Testing
- not run (R environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca73ab9e9083209420a46b153500d5