### PR TITLE
Sanitize app settings from configuration

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -3,6 +3,7 @@
 #' @import shiny
 app_server <- function(input, output, session) {
   db_cfg <- get_db_config()
+  app_settings <- get_app_settings()
   conn <- shiny::reactiveVal(NULL)
 
   shiny::observeEvent(TRUE, {
@@ -71,7 +72,7 @@ app_server <- function(input, output, session) {
   })
 
   shiny::observeEvent(TRUE, {
-    default <- get_golem_config()$app$default_theme %||% "light"
+    default <- app_settings$default_theme
     session$sendCustomMessage("toggle-theme", list(mode = default))
     shinyWidgets::updateMaterialSwitch(session, "theme_toggle", value = identical(default, "dark"))
   }, once = TRUE)

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -3,6 +3,8 @@
 #' Defines the UI layout using bs4Dash components secured by shinymanager.
 #' @import shiny bs4Dash shinyWidgets shinymanager
 app_ui <- function(request) {
+  app_settings <- get_app_settings()
+
   sidebar <- bs4Dash::bs4DashSidebar(
     skin = "light",
     title = "Navigation",
@@ -108,7 +110,7 @@ app_ui <- function(request) {
 
   shinymanager::secure_app(
     ui = add_app_dependencies(ui),
-    language = get_golem_config()$app$language,
+    language = app_settings$language,
     enable_admin = TRUE,
     tags_top = shiny::tags$div(
       shiny::tags$h2("RBudgeting"),

--- a/R/utils_helpers.R
+++ b/R/utils_helpers.R
@@ -6,8 +6,35 @@ app_sys <- function(...) {
   system.file(..., package = "RBudgeting")
 }
 
-#' Add a notification to the navbar menu
+#' Retrieve sanitized application settings
 #'
+#' Ensures configuration values coming from `golem-config.yml` are usable in the
+#' UI and server layers without additional checks.
+#'
+#' @return A list with `language` and `default_theme` entries.
+get_app_settings <- function() {
+  cfg <- get_golem_config()
+  settings <- cfg$app
+
+  if (is.null(settings) || !is.list(settings)) {
+    settings <- list()
+  }
+
+  language <- settings$language
+  if (!is.character(language) || length(language) != 1 || is.na(language)) {
+    language <- "en"
+  }
+
+  default_theme <- settings$default_theme
+  if (!is.character(default_theme) || length(default_theme) != 1 || is.na(default_theme)) {
+    default_theme <- "light"
+  }
+
+  list(language = language, default_theme = default_theme)
+}
+
+#' Add a notification to the navbar menu
+#' 
 #' @param session Shiny session object
 #' @param text Notification text
 #' @param status Status color (info, primary, danger, ...)


### PR DESCRIPTION
## Summary
- add a helper to normalize language and theme settings read from golem-config
- reuse the sanitized values in the UI and server before calling shinymanager or sending theme messages

## Testing
- not run (R is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ca756373888320ae990fa2cb362e65