### PR TITLE
Handle condition messages safely in error notifications

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -13,7 +13,7 @@ app_server <- function(input, output, session) {
       conn(connection)
     }, error = function(e) {
       shiny::showNotification(
-        paste("Failed to connect to database:", e$message),
+        paste("Failed to connect to database:", conditionMessage(e)),
         type = "error",
         duration = NULL
       )

--- a/R/mod_setup.R
+++ b/R/mod_setup.R
@@ -81,8 +81,9 @@ mod_setup_server <- function(id, conn, config) {
         shinyFeedback::showToast("success", success_msg)
         add_notification(session, success_msg, status = status, icon = icon)
       }, error = function(e) {
-        shinyFeedback::showToast("error", paste0(error_msg, ": ", e$message))
-        add_notification(session, paste0(error_msg, ": ", e$message), status = "danger", icon = "exclamation-triangle")
+        message <- conditionMessage(e)
+        shinyFeedback::showToast("error", paste0(error_msg, ": ", message))
+        add_notification(session, paste0(error_msg, ": ", message), status = "danger", icon = "exclamation-triangle")
       })
     }
 
@@ -134,8 +135,9 @@ mod_setup_server <- function(id, conn, config) {
         shinyFeedback::showToast("success", "Database connection refreshed")
         add_notification(session, "Database connection refreshed", status = "success", icon = "plug")
       }, error = function(e) {
-        shinyFeedback::showToast("error", paste("Unable to reconnect:", e$message))
-        add_notification(session, paste("Unable to reconnect:", e$message), status = "danger", icon = "exclamation-triangle")
+        message <- conditionMessage(e)
+        shinyFeedback::showToast("error", paste("Unable to reconnect:", message))
+        add_notification(session, paste("Unable to reconnect:", message), status = "danger", icon = "exclamation-triangle")
       })
     })
 

--- a/R/mod_user_management.R
+++ b/R/mod_user_management.R
@@ -83,8 +83,9 @@ mod_user_management_server <- function(id, conn, auth = NULL) {
         add_notification(session, paste0("User ", input$username, " saved"), status = "success", icon = "user")
         load_users()
       }, error = function(e) {
-        shinyFeedback::showToast("error", paste("Unable to save user:", e$message))
-        add_notification(session, paste("Unable to save user:", e$message), status = "danger", icon = "exclamation-triangle")
+        message <- conditionMessage(e)
+        shinyFeedback::showToast("error", paste("Unable to save user:", message))
+        add_notification(session, paste("Unable to save user:", message), status = "danger", icon = "exclamation-triangle")
       })
     })
 
@@ -106,8 +107,9 @@ mod_user_management_server <- function(id, conn, auth = NULL) {
         add_notification(session, paste0("User ", input$selected_user, ifelse(new_state, " activated", " deactivated")), status = "info", icon = "user-check")
         load_users()
       }, error = function(e) {
-        shinyFeedback::showToast("error", paste("Unable to change state:", e$message))
-        add_notification(session, paste("Unable to change user state:", e$message), status = "danger", icon = "exclamation-triangle")
+        message <- conditionMessage(e)
+        shinyFeedback::showToast("error", paste("Unable to change state:", message))
+        add_notification(session, paste("Unable to change user state:", message), status = "danger", icon = "exclamation-triangle")
       })
     })
 
@@ -124,8 +126,9 @@ mod_user_management_server <- function(id, conn, auth = NULL) {
         add_notification(session, paste0("User ", input$selected_user, " deleted"), status = "warning", icon = "trash")
         load_users()
       }, error = function(e) {
-        shinyFeedback::showToast("error", paste("Unable to delete user:", e$message))
-        add_notification(session, paste("Unable to delete user:", e$message), status = "danger", icon = "exclamation-triangle")
+        message <- conditionMessage(e)
+        shinyFeedback::showToast("error", paste("Unable to delete user:", message))
+        add_notification(session, paste("Unable to delete user:", message), status = "danger", icon = "exclamation-triangle")
       })
     })
 


### PR DESCRIPTION
## Summary
- make error notifications rely on `conditionMessage()` instead of directly accessing `e$message`
- update the setup and user management modules to surface readable error text
- ensure the app server uses the same safe messaging when database connections fail

## Testing
- R -q -e "sessionInfo()" *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7886d42883208191994fcd3e5c8a