### PR TITLE
Fix credential checker return structure

### DIFF
--- a/R/utils_auth.R
+++ b/R/utils_auth.R
@@ -12,23 +12,39 @@ credential_checker <- function(conn_reactive) {
     if (is.null(conn) || !DBI::dbIsValid(conn)) {
       return(list(result = FALSE, message = "Database connection unavailable."))
     }
+
     record <- db_get_user(conn, user)
     if (is.null(record)) {
-      return(FALSE)
+      return(list(result = FALSE, message = "Unknown user"))
     }
+
     if (!isTRUE(record$is_active)) {
       return(list(result = FALSE, message = "Account disabled"))
     }
+
     valid <- shinymanager::check_password(record$password, password)
     if (!isTRUE(valid)) {
-      return(FALSE)
+      return(list(result = FALSE, message = "Invalid credentials"))
     }
+
+    fullname <- record$fullname
+    if (!is.character(fullname) || length(fullname) == 0 || is.na(fullname) || !nzchar(fullname)) {
+      fullname <- record$username
+    }
+
+    # V aplikaci se shinymanager snažil převést návratový objekt na text a narazil na closure,
+    # protože jsme neposkytli očekávané textové pole `user`. Přidáním explicitní hodnoty
+    # uživatele a doplňkových metadat vracíme strukturu, se kterou umí balíček správně pracovat.
     list(
       result = TRUE,
-      user_info = list(
-        user = record$username,
-        fullname = record$fullname %||% record$username,
-        role = record$role
+      user = as.character(record$username),
+      admin = identical(as.character(record$role), "admin"),
+      expire = NA,
+      token = sprintf("rbudgeting-%s-%s", record$username, as.integer(Sys.time())),
+      info = list(
+        id = record$id,
+        fullname = fullname,
+        role = as.character(record$role)
       )
     )
   }


### PR DESCRIPTION
## Summary
- return full metadata from `credential_checker()` including expected `user` field for shinymanager
- document in code (in Czech) the root cause and why the new structure avoids the closure coercion warning

## Testing
- not run (R runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca7dddb94c8320b799f4c8dcdf70fd