### PR TITLE
Handle bs4Dash dependency helper availability

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -109,7 +109,7 @@ app_ui <- function(request) {
   setup_public <- shiny::div(
     id = "public-setup",
     class = "setup-public-container",
-    bs4Dash::useBs4Dash(),
+    use_bs4dash_dependencies(),
     setup_header,
     mod_setup_ui("setup")
   )

--- a/R/utils_helpers.R
+++ b/R/utils_helpers.R
@@ -33,6 +33,32 @@ get_app_settings <- function() {
   list(language = language, default_theme = default_theme)
 }
 
+#' Use bs4Dash dependencies across versions
+#'
+#' The exported helper for attaching bs4Dash assets changed between
+#' package releases. This wrapper tries the available function without
+#' triggering errors on older or newer versions.
+use_bs4dash_dependencies <- function() {
+  exported <- getNamespaceExports("bs4Dash")
+
+  if ("useBs4Dash" %in% exported) {
+    return(bs4Dash::useBs4Dash())
+  }
+  if ("use_bs4dash" %in% exported) {
+    return(bs4Dash::use_bs4dash())
+  }
+
+  ns <- asNamespace("bs4Dash")
+  if (exists("useBs4Dash", envir = ns, inherits = FALSE)) {
+    return(get("useBs4Dash", envir = ns)())
+  }
+  if (exists("use_bs4dash", envir = ns, inherits = FALSE)) {
+    return(get("use_bs4dash", envir = ns)())
+  }
+
+  shiny::tagList()
+}
+
 #' Add a notification to the navbar menu
 #' 
 #' @param session Shiny session object


### PR DESCRIPTION
## Summary
- add a compatibility helper that safely invokes the available bs4Dash dependency loader across package versions
- update the setup UI to use the compatibility helper so startup succeeds even when `useBs4Dash` is unexported

## Testing
- not run (R executable not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca8e7d2c408320aa8b03a96e3d750a