### PR TITLE
Handle function values in credential sanitizer

### DIFF
--- a/R/utils_auth.R
+++ b/R/utils_auth.R
@@ -13,6 +13,10 @@ credential_checker <- function(conn_reactive) {
       return(default)
     }
 
+    if (is.function(value)) {
+      return(default)
+    }
+
     coerced <- tryCatch(as.character(value), error = function(e) character())
     if (length(coerced) == 0 || is.na(coerced[1]) || !nzchar(coerced[1])) {
       default


### PR DESCRIPTION
## Summary
- prevent the credential field sanitizer from attempting to coerce functions to character strings
- ensure shinymanager authentication gracefully ignores unexpected closure values

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca91ee294483208c2ad4377083a57a