### PR TITLE
Sanitize configuration values before using them

### DIFF
--- a/R/app_config.R
+++ b/R/app_config.R
@@ -15,5 +15,34 @@ get_golem_config <- function(config = c("default", "production")) {
 #' @return A list containing database connection parameters.
 get_db_config <- function() {
   cfg <- get_golem_config()
-  cfg$db
+  db <- cfg$db
+
+  if (is.null(db) || !is.list(db)) {
+    db <- list()
+  }
+
+  host <- sanitize_scalar_character(db$host, default = "localhost")
+  port <- sanitize_scalar_integer(db$port, default = 5432L, min = 1L, max = 65535L)
+  if (is.na(port)) {
+    port <- 5432L
+  }
+
+  dbname <- sanitize_scalar_character(db$dbname, default = "rbudgeting")
+  user <- sanitize_scalar_character(db$user, default = "")
+  password <- sanitize_scalar_character(db$password, default = "", allow_empty = TRUE)
+
+  sslmode <- sanitize_scalar_character(db$sslmode, default = "prefer")
+  allowed_ssl <- c("disable", "allow", "prefer", "require", "verify-ca", "verify-full")
+  if (!sslmode %in% allowed_ssl) {
+    sslmode <- "prefer"
+  }
+
+  list(
+    host = host,
+    port = port,
+    dbname = dbname,
+    user = user,
+    password = password,
+    sslmode = sslmode
+  )
 }

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -4,6 +4,24 @@
 app_server <- function(input, output, session) {
   db_cfg <- get_db_config()
   app_settings <- get_app_settings()
+  message(
+    "[app_server] Database config: host=",
+    db_cfg$host,
+    ", port=",
+    db_cfg$port,
+    ", dbname=",
+    db_cfg$dbname,
+    ", user=",
+    db_cfg$user,
+    ", sslmode=",
+    db_cfg$sslmode
+  )
+  message(
+    "[app_server] App settings: language=",
+    app_settings$language,
+    ", default_theme=",
+    app_settings$default_theme
+  )
   conn <- shiny::reactiveVal(NULL)
 
   shiny::observeEvent(TRUE, {


### PR DESCRIPTION
## Summary
- sanitize database configuration values before they reach the UI or server logic
- add reusable scalar sanitizers for character and integer settings and use them for app settings
- log the sanitized configuration and application settings when the server starts to aid debugging

## Testing
- Not run (R binary is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ca9313ffcc832098a9532235a86666