### PR TITLE
Handle logging of non-character values

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -5,22 +5,21 @@ app_server <- function(input, output, session) {
   db_cfg <- get_db_config()
   app_settings <- get_app_settings()
   message(
-    "[app_server] Database config: host=",
-    db_cfg$host,
-    ", port=",
-    db_cfg$port,
-    ", dbname=",
-    db_cfg$dbname,
-    ", user=",
-    db_cfg$user,
-    ", sslmode=",
-    db_cfg$sslmode
+    sprintf(
+      "[app_server] Database config: host=%s, port=%s, dbname=%s, user=%s, sslmode=%s",
+      format_scalar_for_log(db_cfg$host),
+      format_scalar_for_log(db_cfg$port),
+      format_scalar_for_log(db_cfg$dbname),
+      format_scalar_for_log(db_cfg$user),
+      format_scalar_for_log(db_cfg$sslmode)
+    )
   )
   message(
-    "[app_server] App settings: language=",
-    app_settings$language,
-    ", default_theme=",
-    app_settings$default_theme
+    sprintf(
+      "[app_server] App settings: language=%s, default_theme=%s",
+      format_scalar_for_log(app_settings$language),
+      format_scalar_for_log(app_settings$default_theme)
+    )
   )
   conn <- shiny::reactiveVal(NULL)
 

--- a/R/utils_helpers.R
+++ b/R/utils_helpers.R
@@ -209,6 +209,35 @@ sanitize_scalar_integer <- function(value, default = NA_integer_, min = NULL, ma
   candidate
 }
 
+#' Safely format a scalar value for logging
+#'
+#' Converts arbitrary inputs into a character representation suitable for
+#' concatenation in log messages while avoiding errors when functions or other
+#' unsupported objects are supplied.
+#'
+#' @param value Value to format.
+#' @param fallback String to use when the value cannot be represented.
+#' @return A single character string.
+format_scalar_for_log <- function(value, fallback = "<unavailable>") {
+  if (is.null(value)) {
+    return("NULL")
+  }
+  if (is.function(value)) {
+    return("<function>")
+  }
+
+  coerced <- tryCatch(
+    as.character(value),
+    error = function(e) character()
+  )
+
+  if (length(coerced) == 0 || is.na(coerced[1])) {
+    return(fallback)
+  }
+
+  coerced[[1]]
+}
+
 #' Use bs4Dash dependencies across versions
 #'
 #' The exported helper for attaching bs4Dash assets changed between


### PR DESCRIPTION
## Summary
- add a helper that safely formats arbitrary values for logging without coercion errors
- log database configuration and app settings in a single sprintf call so only character data is passed to message()

## Testing
- not run (R runtime unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca97032ac08320828186e99e4aad07