### PR TITLE
Fix authentication reactive usage

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -96,8 +96,8 @@ app_server <- function(input, output, session) {
 
   mod_setup_server("setup", conn = conn, config = db_cfg)
 
-  shiny::observeEvent(auth$result, {
-    authed <- isTRUE(auth$result)
+  shiny::observeEvent(auth$result(), {
+    authed <- isTRUE(auth$result())
 
     if (authed) {
       shinyjs::addClass(id = "public-setup", class = "public-hidden")
@@ -113,8 +113,8 @@ app_server <- function(input, output, session) {
     }
   }, ignoreNULL = FALSE)
 
-  shiny::observeEvent(auth$result, {
-    req(isTRUE(auth$result))
+  shiny::observeEvent(auth$result(), {
+    req(isTRUE(auth$result()))
     mod_user_management_server("user_management", conn = conn)
   }, once = TRUE)
 


### PR DESCRIPTION
## Summary
- call the shinymanager authentication result reactive correctly by invoking `auth$result()` inside observers
- ensure downstream logic uses the boolean value instead of the reactive function to update UI state and initialize modules

## Testing
- not run (R is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68ca9e7335c4832097931dd7a651b7b9