### PR TITLE
Enable persistent database configuration and login access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
-app_config.yml
+/app_config.yml

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Imports:
     shinyjs,
     shinymanager,
     shinyWidgets,
+    yaml,
     utils
 Suggests:
     testthat (>= 3.0.0)

--- a/R/app_config.R
+++ b/R/app_config.R
@@ -12,24 +12,47 @@ get_golem_config <- function(config = c("default", "production")) {
   resolved
 }
 
-#' Read database configuration
+#' Determine the path to the runtime application configuration file
 #'
-#' @return A list containing database connection parameters.
-get_db_config <- function() {
-  cfg <- get_golem_config()
-  db <- cfg$db
+#' The path can be overridden via the `RBUDGETING_APP_CONFIG` environment
+#' variable; otherwise the package copy shipped in `inst/app/app_config.yml`
+#' is used. When neither is available, the file is created inside the current
+#' working directory.
+get_app_config_path <- function() {
+  env_path <- Sys.getenv("RBUDGETING_APP_CONFIG", unset = NA_character_)
+  if (!is.na(env_path) && nzchar(env_path)) {
+    normalized <- tryCatch(
+      normalizePath(env_path, winslash = "/", mustWork = FALSE),
+      error = function(e) env_path
+    )
+    log_debug("get_app_config_path.env", "Using path '", normalized, "'.")
+    return(normalized)
+  }
 
+  pkg_path <- app_sys("app", "app_config.yml")
+  if (!is.null(pkg_path) && nzchar(pkg_path)) {
+    log_debug("get_app_config_path.pkg", "Using package path '", pkg_path, "'.")
+    return(pkg_path)
+  }
+
+  fallback <- file.path(getwd(), "app_config.yml")
+  log_debug("get_app_config_path.fallback", "Using fallback path '", fallback, "'.")
+  fallback
+}
+
+#' Internal helper to sanitise a database configuration list
+#' @noRd
+sanitize_db_configuration <- function(db) {
   if (is.null(db) || !is.list(db)) {
-    log_debug("get_db_config", "Database configuration missing or invalid, using defaults.")
     db <- list()
   }
 
-  log_structure("get_db_config.raw", db)
+  log_structure("sanitize_db_configuration.input", db)
 
   host <- sanitize_scalar_character(db$host, default = "localhost")
   port <- sanitize_scalar_integer(db$port, default = 5432L, min = 1L, max = 65535L)
   if (is.na(port)) {
-    log_debug("get_db_config", "Port sanitization returned NA; fallback to 5432.")
+    log_debug("sanitize_db_configuration", "Port sanitization returned NA; fallback to 5432.")
     port <- 5432L
   }
 
@@ -51,6 +74,84 @@ get_db_config <- function() {
     password = password,
     sslmode = sslmode
   )
-  log_structure("get_db_config.sanitized", sanitized)
+  log_structure("sanitize_db_configuration.output", sanitized)
+  sanitized
+}
+
+#' Read runtime database configuration from disk
+#' @noRd
+load_persisted_db_config <- function() {
+  path <- get_app_config_path()
+  if (!file.exists(path)) {
+    log_debug("load_persisted_db_config", "Configuration file '", path, "' not found.")
+    return(NULL)
+  }
+
+  tryCatch(
+    {
+      cfg <- yaml::read_yaml(path, eval.expr = FALSE)
+      log_structure("load_persisted_db_config.raw", cfg)
+      if (is.list(cfg$db)) {
+        return(cfg$db)
+      }
+      cfg
+    },
+    error = function(e) {
+      log_debug(
+        "load_persisted_db_config", "Unable to read configuration '", path, "': ", conditionMessage(e)
+      )
+      NULL
+    }
+  )
+}
+
+#' Persist database configuration to disk
+#' @noRd
+save_db_config <- function(db_cfg) {
+  sanitized <- sanitize_db_configuration(db_cfg)
+  path <- get_app_config_path()
+
+  dir_path <- dirname(path)
+  if (!dir.exists(dir_path)) {
+    ok <- dir.create(dir_path, recursive = TRUE, showWarnings = FALSE)
+    if (!ok) {
+      stop(sprintf("Unable to create configuration directory '%s'.", dir_path))
+    }
+  }
+
+  log_structure("save_db_config.sanitized", sanitized)
+
+  tryCatch(
+    {
+      yaml::write_yaml(list(db = sanitized), path)
+      log_debug("save_db_config", "Configuration written to '", path, "'.")
+      invisible(sanitized)
+    },
+    error = function(e) {
+      stop(sprintf("Unable to write configuration file '%s': %s", path, conditionMessage(e)))
+    }
+  )
+}
+
+#' Read database configuration
+#'
+#' @return A list containing database connection parameters.
+get_db_config <- function() {
+  defaults <- get_golem_config()
+  db <- defaults$db
+
+  if (is.null(db) || !is.list(db)) {
+    log_debug("get_db_config", "Database configuration missing or invalid in golem-config; using defaults.")
+    db <- list()
+  }
+
+  stored <- load_persisted_db_config()
+  if (is.list(stored) && length(stored) > 0) {
+    log_structure("get_db_config.persisted", stored)
+    db <- utils::modifyList(db, stored)
+  }
+
+  sanitized <- sanitize_db_configuration(db)
+  log_structure("get_db_config.final", sanitized)
   sanitized
 }

--- a/inst/app/app_config.yml
+++ b/inst/app/app_config.yml
@@ -1,0 +1,9 @@
+# Runtime configuration for RBudgeting database connection.
+# This file is updated by the setup module when credentials are stored.
+db:
+  host: localhost
+  port: 5432
+  dbname: rbudgeting
+  user: rbudget_app
+  password: change_me
+  sslmode: prefer


### PR DESCRIPTION
## Summary
- add a runtime app configuration file and helper functions to read, sanitize, and persist database settings
- extend the setup module with load/persist actions, connection refresh utilities, and a login shortcut button
- allow packaging of the runtime configuration file by refining .gitignore

## Testing
- ⚠️ `R -q -e "devtools::check(document = FALSE, error_on = 'error')"` *(fails: R command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0fcda2a48320bbbac33b4dd2fc19