### PR TITLE
Add shinymanager password compatibility helper

### DIFF
--- a/R/utils_auth.R
+++ b/R/utils_auth.R
@@ -108,7 +108,7 @@ credential_checker <- function(conn_reactive) {
           return(failure_response("Account disabled", user))
         }
 
-        valid <- shinymanager::check_password(record$password, password)
+        valid <- check_password_compat(record$password, password)
         if (!isTRUE(valid)) {
           log_debug("credential_checker", "Invalid password provided for user '", user, "'.")
           return(failure_response("Invalid credentials", user))


### PR DESCRIPTION
## Summary
- add a compatibility helper that uses available shinymanager or sodium utilities to verify passwords
- switch the credential checker to rely on the compatibility helper instead of the non-exported check_password

## Testing
- not run (Rscript is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cbb3d7d50883209e3f71738dde4a55