### PR TITLE
Fix reactive context error when disconnecting

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -38,7 +38,8 @@ app_server <- function(input, output, session) {
   }, once = TRUE)
 
   shiny::onStop(function() {
-    db_disconnect(conn())
+    connection <- shiny::isolate(conn())
+    db_disconnect(connection)
   })
 
   auth <- shinymanager::secure_server(


### PR DESCRIPTION
## Summary
- avoid touching the reactive connection object outside of a reactive context when the session stops
- ensure the database connection is retrieved with `shiny::isolate()` before disconnecting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbb6fe0d688320985725bf81f48ba8