### PR TITLE
Fix bs4Dash navbar compatibility and redact sensitive logs

### DIFF
--- a/R/app_config.R
+++ b/R/app_config.R
@@ -8,7 +8,7 @@ get_golem_config <- function(config = c("default", "production")) {
     file = app_sys("golem-config.yml"),
     use_parent = FALSE
   )
-  log_structure("get_golem_config.result", resolved)
+  log_structure("get_golem_config.result", redact_sensitive(resolved))
   resolved
 }
 
@@ -47,7 +47,7 @@ sanitize_db_configuration <- function(db) {
     db <- list()
   }
 
-  log_structure("sanitize_db_configuration.input", db)
+  log_structure("sanitize_db_configuration.input", redact_sensitive(db))
 
   host <- sanitize_scalar_character(db$host, default = "localhost")
   port <- sanitize_scalar_integer(db$port, default = 5432L, min = 1L, max = 65535L)
@@ -58,7 +58,12 @@ sanitize_db_configuration <- function(db) {
 
   dbname <- sanitize_scalar_character(db$dbname, default = "rbudgeting")
   user <- sanitize_scalar_character(db$user, default = "")
-  password <- sanitize_scalar_character(db$password, default = "", allow_empty = TRUE)
+  password <- sanitize_scalar_character(
+    db$password,
+    default = "",
+    allow_empty = TRUE,
+    sensitive = TRUE
+  )
 
   sslmode <- sanitize_scalar_character(db$sslmode, default = "prefer")
   allowed_ssl <- c("disable", "allow", "prefer", "require", "verify-ca", "verify-full")
@@ -74,7 +79,7 @@ sanitize_db_configuration <- function(db) {
     password = password,
     sslmode = sslmode
   )
-  log_structure("sanitize_db_configuration.output", sanitized)
+  log_structure("sanitize_db_configuration.output", redact_sensitive(sanitized))
   sanitized
 }
 
@@ -90,7 +95,7 @@ load_persisted_db_config <- function() {
   tryCatch(
     {
       cfg <- yaml::read_yaml(path, eval.expr = FALSE)
-      log_structure("load_persisted_db_config.raw", cfg)
+      log_structure("load_persisted_db_config.raw", redact_sensitive(cfg))
       if (is.list(cfg$db)) {
         return(cfg$db)
       }
@@ -119,7 +124,7 @@ save_db_config <- function(db_cfg) {
     }
   }
 
-  log_structure("save_db_config.sanitized", sanitized)
+  log_structure("save_db_config.sanitized", redact_sensitive(sanitized))
 
   tryCatch(
     {
@@ -147,11 +152,11 @@ get_db_config <- function() {
 
   stored <- load_persisted_db_config()
   if (is.list(stored) && length(stored) > 0) {
-    log_structure("get_db_config.persisted", stored)
+    log_structure("get_db_config.persisted", redact_sensitive(stored))
     db <- utils::modifyList(db, stored)
   }
 
   sanitized <- sanitize_db_configuration(db)
-  log_structure("get_db_config.final", sanitized)
+  log_structure("get_db_config.final", redact_sensitive(sanitized))
   sanitized
 }

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -136,23 +136,20 @@ app_ui <- function(request) {
   )
 
   available_args <- names(formals(bs4Dash::bs4DashPage))
-  message(
-    sprintf(
-      "[app_ui] Detected %d available bs4Dash::bs4DashPage arguments.",
-      length(available_args)
-    )
-  )
-  log_structure("app_ui.available_args", available_args)
 
-  if (!"navbar" %in% available_args && "header" %in% available_args && "navbar" %in% names(page_args)) {
-    page_args$header <- page_args$navbar
-  }
-  if (!"controlbar" %in% available_args && "rightsidebar" %in% available_args && "controlbar" %in% names(page_args)) {
-    page_args$rightsidebar <- page_args$controlbar
+  adapt_page_args <- function(args) {
+    if (!"navbar" %in% available_args && "header" %in% available_args && "navbar" %in% names(args)) {
+      args$header <- args$navbar
+      args$navbar <- NULL
+    }
+    if (!"controlbar" %in% available_args && "rightsidebar" %in% available_args && "controlbar" %in% names(args)) {
+      args$rightsidebar <- args$controlbar
+      args$controlbar <- NULL
+    }
+    args[names(args) %in% available_args]
   }
 
-  page_args <- page_args[names(page_args) %in% available_args]
-  log_structure("app_ui.page_args", page_args)
+  page_args <- adapt_page_args(page_args)
   secure_ui <- tryCatch(
     {
       ui_obj <- do.call(bs4Dash::bs4DashPage, page_args)
@@ -249,18 +246,20 @@ app_ui <- function(request) {
     right = shiny::HTML("<b>Version</b> 0.0.1")
   )
 
+  public_page_args <- adapt_page_args(list(
+    title = "RBudgeting",
+    freshTheme = NULL,
+    preloader = list(html = NULL, color = "#3c8dbc"),
+    navbar = public_navbar,
+    sidebar = public_sidebar,
+    footer = public_footer,
+    body = public_body
+  ))
+
   setup_public <- shiny::div(
     id = "public-shell",
     class = "setup-public-container",
-    bs4Dash::bs4DashPage(
-      title = "RBudgeting",
-      freshTheme = NULL,
-      preloader = list(html = NULL, color = "#3c8dbc"),
-      navbar = public_navbar,
-      sidebar = public_sidebar,
-      footer = public_footer,
-      body = public_body
-    )
+    do.call(bs4Dash::bs4DashPage, public_page_args)
   )
   message(
     sprintf(

--- a/R/mod_setup.R
+++ b/R/mod_setup.R
@@ -5,7 +5,7 @@
 mod_setup_ui <- function(id) {
   ns <- shiny::NS(id)
   cfg <- get_db_config()
-  log_structure("mod_setup_ui.config_defaults", cfg)
+  log_structure("mod_setup_ui.config_defaults", redact_sensitive(cfg))
   shiny::tagList(
     bs4Dash::bs4Card(
       title = "Database installation",


### PR DESCRIPTION
## Summary
- add a helper that redacts sensitive fields before structured logging and skip echoing sanitized secrets
- ensure configuration logging paths mask persisted database passwords
- adapt bs4Dash page argument handling so both secure and public shells work without the deprecated navbar argument

## Testing
- not run (Rscript is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cbe3c057288320a66f6356afaa676d