### PR TITLE
Fix navbar builder to drop NULL right UI items

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -76,7 +76,7 @@ app_ui <- function(request) {
       )
     }
 
-    right_ui <- shiny::tagList(
+    right_ui_items <- list(
       shiny::tags$li(
         class = "nav-item dropdown d-flex align-items-center px-3",
         shiny::icon("user-circle", class = "mr-2"),
@@ -101,6 +101,9 @@ app_ui <- function(request) {
         auth_button
       )
     )
+
+    right_ui_items <- Filter(Negate(is.null), right_ui_items)
+    right_ui <- do.call(shiny::tagList, right_ui_items)
 
     bs4Dash::bs4DashNavbar(
       title = shiny::tags$span("RBudgeting"),


### PR DESCRIPTION
## Summary
- ensure the navbar builder removes NULL entries before passing them to `bs4DashNavbar`
- build the right-side UI using a filtered list so the navbar assertion only sees valid tags

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbeb8940b48320a8d6ab27c84cabb8