### PR TITLE
Add shinymanager logout compatibility wrapper

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -46,7 +46,7 @@ app_server <- function(input, output, session) {
     session = session
   )
 
-  shinymanager::logoutServer(id = "logout", active = shiny::reactive(auth$result))
+  shinymanager_logout_module(id = "logout", active = shiny::reactive(auth$result))
 
   is_authenticated <- shiny::reactive({
     isTRUE(auth$result)

--- a/R/shinymanager_compat.R
+++ b/R/shinymanager_compat.R
@@ -1,0 +1,32 @@
+# Compatibility helpers for shinymanager API changes ----
+
+#' Invoke shinymanager logout module in a version agnostic way
+#'
+#' Recent versions of shinymanager renamed the logout module from
+#' `logoutServer` to `logout_server`. Older releases only provide the former
+#' camelCase export. This helper looks for the available implementation at
+#' runtime and invokes it with the supplied arguments.
+#'
+#' @param ... Arguments forwarded to the underlying shinymanager logout module.
+shinymanager_logout_module <- function(...) {
+  fun <- find_shinymanager_function(c("logoutServer", "logout_server"))
+  if (is.null(fun)) {
+    stop("Unable to locate a shinymanager logout module.", call. = FALSE)
+  }
+  fun(...)
+}
+
+find_shinymanager_function <- function(candidates) {
+  if (!requireNamespace("shinymanager", quietly = TRUE)) {
+    return(NULL)
+  }
+
+  exports <- tryCatch(utils::getNamespaceExports("shinymanager"), error = function(...) character())
+  for (candidate in candidates) {
+    if (candidate %in% exports) {
+      return(getExportedValue("shinymanager", candidate))
+    }
+  }
+
+  NULL
+}


### PR DESCRIPTION
## Summary
- add a compatibility helper that resolves the shinymanager logout module name at runtime
- switch the server logic to invoke the compatibility helper so the app works across shinymanager releases

## Testing
- not run (R is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cbfa1915108320ad97cb17798a377c