### PR TITLE
Expand shinymanager logout compatibility

### DIFF
--- a/R/shinymanager_compat.R
+++ b/R/shinymanager_compat.R
@@ -9,7 +9,9 @@
 #'
 #' @param ... Arguments forwarded to the underlying shinymanager logout module.
 shinymanager_logout_module <- function(...) {
-  fun <- find_shinymanager_function(c("logoutServer", "logout_server"))
+  fun <- find_shinymanager_function(
+    c("logoutServer", "logout_server", "logout_module_server")
+  )
   if (is.null(fun)) {
     stop("Unable to locate a shinymanager logout module.", call. = FALSE)
   }


### PR DESCRIPTION
## Summary
- extend the shinymanager logout compatibility helper to look for the latest module export name

## Testing
- not run (R interpreter is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cbfbbe0d908320a2f16620af2cd19e