### PR TITLE
Fix shinymanager auth server invocation

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -41,9 +41,10 @@ app_server <- function(input, output, session) {
     db_disconnect(connection)
   })
 
-  auth <- shinymanager::auth_server(
-    check_credentials = credential_checker(conn),
-    session = session
+  auth <- shinymanager_auth_server(
+    "auth",
+    session = session,
+    check_credentials = credential_checker(conn)
   )
 
   shinymanager_logout_module(id = "logout", active = shiny::reactive(auth$result))


### PR DESCRIPTION
## Summary
- add a compatibility helper that adapts to shinymanager::auth_server API changes
- update the main server to use the new helper instead of calling auth_server directly

## Testing
- not run (R is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc03adc2a4832088840cefb1a3f98e