### PR TITLE
Fix nav selection function call

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -87,11 +87,11 @@ app_server <- function(input, output, session) {
   })
 
   shiny::observeEvent(input$show_login, {
-    bslib::update_navs(session, "main_nav", selected = "content")
+    bslib::nav_select(session = session, id = "main_nav", selected = "content")
   })
 
   shiny::observeEvent(input$show_login_users, {
-    bslib::update_navs(session, "main_nav", selected = "content")
+    bslib::nav_select(session = session, id = "main_nav", selected = "content")
   })
 
   output$content_nav <- shiny::renderUI({


### PR DESCRIPTION
## Summary
- replace the deprecated/non-exported `bslib::update_navs()` call with `bslib::nav_select()` to switch the main navigation to the content tab when prompting for login

## Testing
- not run (R environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc12051b108320854de0cb6e209438