### PR TITLE
Ensure user management module is always initialized

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -118,8 +118,5 @@ app_server <- function(input, output, session) {
   mod_setup_server("setup", conn = conn, config = db_cfg)
   mod_content_server("content", current_user = current_user, is_authenticated = is_authenticated)
 
-  shiny::observeEvent(is_authenticated(), {
-    shiny::req(is_authenticated())
-    mod_user_management_server("user_management", conn = conn)
-  }, once = TRUE)
+  mod_user_management_server("user_management", conn = conn)
 }


### PR DESCRIPTION
## Summary
- initialize the user management module server unconditionally so the user list renders as soon as authentication is available

## Testing
- R -q -e "devtools::check()" *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_68cc241826d88320823673ecfb37961b