### PR TITLE
Enhance user admin actions and persist theme preference

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -16,6 +16,7 @@ app_ui <- function(request) {
     bslib::nav_panel("Instalace", value = "setup", mod_setup_ui("setup")),
     bslib::nav_panel("Obsah", value = "content", shiny::uiOutput("content_nav")),
     bslib::nav_panel("Uživatelé", value = "users", shiny::uiOutput("users_panel")),
+    bslib::nav_item(shiny::uiOutput("theme_toggle_ui")),
     bslib::nav_spacer(),
     bslib::nav_item(
       shiny::div(class = "navbar-text", shiny::uiOutput("user_badge"))


### PR DESCRIPTION
## Summary
- replace the extra action card in the user management module with toolbar buttons tied to the table selection and enable bulk activate/deactivate/delete operations
- extend the users table with stored theme preferences and add helper utilities plus schema migration to keep the column in sync
- add a navbar toggle for dark/light theme that persists the choice per user and reapplies it on login

## Testing
- R -q -e "devtools::test()" *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_68cc27ce9ce083208b9654c0566c09a9