### PR TITLE
Add user role editing modal

### DIFF
--- a/R/utils_db.R
+++ b/R/utils_db.R
@@ -210,6 +210,26 @@ db_get_user <- function(conn, username) {
   res[1, , drop = FALSE]
 }
 
+#' Update user profile information without changing credentials
+#' @param conn Active connection
+#' @param username Username to update
+#' @param fullname New full name (can be NULL to clear)
+#' @param role New role identifier
+#' @return TRUE when update executed
+db_update_user_profile <- function(conn, username, fullname = NULL, role) {
+  stopifnot(DBI::dbIsValid(conn))
+  if (missing(role) || is.null(role) || length(role) == 0) {
+    stop("Role musí být vyplněna.")
+  }
+  role_value <- as.character(role[1])
+  if (!isTRUE(nzchar(role_value))) {
+    stop("Role musí být vyplněna.")
+  }
+  query <- "UPDATE app_users SET fullname = $2, role = $3, updated_at = NOW() WHERE username = $1;"
+  DBI::dbExecute(conn, query, params = list(username, fullname, role_value))
+  TRUE
+}
+
 #' Toggle user activation
 #' @param conn Active connection
 #' @param username Username to change


### PR DESCRIPTION
## Summary
- add an Editace action to the user table to open a modal with full name and role fields
- handle modal interactions server-side, including validation and persistence of updates
- introduce a database helper to update a user's profile without changing credentials

## Testing
- ⚠️ `Rscript -e 'if (dir.exists("tests")) testthat::test_dir("tests") else cat("No tests directory present\n")'` *(fails: `Rscript` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cce5b1badc8320a500e04cb445cac6