### PR TITLE
Fix missing ns helper in user management module

### DIFF
--- a/R/mod_user_management.R
+++ b/R/mod_user_management.R
@@ -66,6 +66,7 @@ mod_user_management_ui <- function(id) {
 #' @param auth Deprecated
 mod_user_management_server <- function(id, conn, auth = NULL) {
   shiny::moduleServer(id, function(input, output, session) {
+    ns <- session$ns
 
     user_admin_log <- function(event, ...) {
       fragments <- c(event, ...)


### PR DESCRIPTION
## Summary
- define the module namespace helper inside the user management server
- ensure Shiny namespace lookups resolve during edit modal creation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccf1cc98f08320849f0d2b520609ae